### PR TITLE
Initialize project structure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Ignore Python cache
+__pycache__/
+*.pyc
+
+# Ignore temporary files
+*.log
+*.tmp
+*.swp
+
+# Ignore system files
+.DS_Store
+Thumbs.db
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Marcos Paulo Pazzinatto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights  
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      
+copies of the Software, and to permit persons to whom the Software is         
+furnished to do so, subject to the following conditions:                       
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.                                
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  
+SOFTWARE.
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,15 @@
+# Chaos Engineering Toolkit Documentation
+
+This section provides detailed explanations about each chaos scenario.
+
+## Scenarios
+- **Pod Kill**: Randomly deletes one pod in a namespace.
+- **Node Drain**: Evicts pods from a node to simulate node failure.
+- **Network Latency**: Adds artificial delay in communication.
+- **Packet Loss**: Simulates packet drops in network traffic.
+- **Disk Full**: Fills up storage space to simulate disk pressure.
+- **High CPU Load**: Creates artificial CPU starvation.
+
+## Usage
+Each scenario can be applied using `kubectl apply -f <file>`.
+

--- a/scenarios/pod-kill.yaml
+++ b/scenarios/pod-kill.yaml
@@ -1,0 +1,12 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: pod-kill-example
+  namespace: chaos-testing
+spec:
+  action: pod-kill
+  mode: one
+  selector:
+    namespaces:
+      - default
+

--- a/scripts/stress-cpu.sh
+++ b/scripts/stress-cpu.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Simulate high CPU load
+
+echo "Starting CPU stress test..."
+stress --cpu 2 --timeout 60
+echo "CPU stress test completed."
+


### PR DESCRIPTION
This PR initializes the Chaos Engineering Toolkit repository with the following files:

- Added README.md with project overview and usage instructions.
- Added MIT LICENSE.
- Added .gitignore for temporary and system files.
- Created initial scenarios folder with pod-kill.yaml example.
- Added scripts folder with stress-cpu.sh example.
- Added docs folder with overview.md for documentation.

This sets the foundation for future chaos scenarios and experiments.
