### PR TITLE
Add node-drain chaos scenario

### DIFF
--- a/scenarios/node-drain.yaml
+++ b/scenarios/node-drain.yaml
@@ -1,0 +1,19 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: StressChaos
+metadata:
+  name: node-drain-example
+  namespace: chaos-testing
+spec:
+  mode: one
+  selector:
+    nodes:
+      - <node-name>
+  stressors:
+    cpu:
+      workers: 2
+      load: 80
+    memory:
+      workers: 1
+      size: "500Mi"
+  duration: "2m"
+


### PR DESCRIPTION
This PR introduces a new chaos scenario to simulate node drain conditions.

- Added scenarios/node-drain.yaml using StressChaos.
- Simulates CPU and memory pressure on a specific node.
- Allows testing workload resilience during node stress events.
