### PR TITLE
Add packet loss chaos scenario

### DIFF
--- a/scenarios/packet-loss.yaml
+++ b/scenarios/packet-loss.yaml
@@ -1,0 +1,16 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: packet-loss-example
+  namespace: chaos-testing
+spec:
+  action: loss
+  mode: all
+  selector:
+    namespaces:
+      - default
+  loss:
+    loss: "30"
+    correlation: "50"
+  duration: "2m"
+


### PR DESCRIPTION
This PR adds a new chaos scenario to simulate packet loss conditions.

- Added scenarios/packet-loss.yaml using NetworkChaos.
- Configured 30% packet loss with 50% correlation.
- Enables testing of application resilience against unreliable network conditions.
